### PR TITLE
Refactor: Remove one-time job execution in time service and switch to…

### DIFF
--- a/design/time-service.md
+++ b/design/time-service.md
@@ -6,7 +6,7 @@ Created: June 23, 2025
 ## Description
 Time service for event automation and pet system.  
 This module is part of our Discord bot.  
-Supports cron jobs and one-time tasks (e.g. ranking, reminders).
+Supports cron jobs.
 
 ## Proposed Design
 
@@ -27,10 +27,6 @@ src/
 │   ├── monthly/
 │   │   └── rankingJobs.js           # Monthly rank
 │   │
-│   └── reminder/
-│       ├── eventReminderJob.js      # One-time reminder before event
-│       ├── eventStartJob.js         # One-time trigger at event start
-│       └── recordingJob.js          # One-time voice recording trigger
 ```
 
 ```Flow
@@ -62,48 +58,4 @@ Time Service Flow
                         ├────────────────────────────┤
                         │  e.g. update ranking       │
                         └────────────────────────────┘
-
-
-        ┌────────────┐
-        │ Discord UI │───▶ User creates event with Discord UserID (<@DC_ID>)
-        └────────────┘
-               │     Manual action
-               ▼
-     ┌────────────────────────┐
-     │    scheduleTask()      │ ◀─────────────┐
-     ├────────────────────────┤               │
-     │ - Save task to DB      │               │
-     │ - Push to delay queue  │               │
-     └────────────────────────┘               │
-               │                              │
-               ▼                              │
-        Task enqueued                         ▼
-               │                  ┌────────────────────────────┐
-               │                  │   App Restart / Startup    │
-               │                  └────────────────────────────┘
-               │                              │
-               │                              ▼
-               │          ┌────────────────────────────────┐
-               │          │ TimeService.initWorker()       │
-               │          ├────────────────────────────────┤
-               │          │ - Load tasks from DB           │
-               │          │ - scheduleTask() → queue       │                  
-               │          └────────────────────────────────┘
-               │                              │
-               ▼                              │
-     ┌────────────────────────────┐           │
-     │ Starts listening to queue  │  ◀────────┘    
-     └────────────────────────────┘
-               │
-          delay expires
-               │
-               ▼
-     ┌────────────────────────────┐
-     │       Execute Job          │
-     ├────────────────────────────┤
-     │ e.g.                       │
-     │ - eventReminderJob         │
-     │ - eventStartJob            │
-     │ - recordingJob             │
-     └────────────────────────────┘
 ```


### PR DESCRIPTION
Remove one-time job handling in time service since it can be triggered by event start UI in DC
For the future this event-job handling will be integrated with the command /活動開始 /活動結束